### PR TITLE
support gif and cml formats, fix bugs

### DIFF
--- a/api_database/django_project/api/filters.py
+++ b/api_database/django_project/api/filters.py
@@ -65,6 +65,27 @@ def get_reduced_cell(params: list, centring: str) -> list:
     return list(reduced_params)
 
 
+def general_refcode_filter(request, queryset, value):
+    exact = False
+    if request:
+        exact = request.GET.get('exact', False)
+    if value:
+        queryset_temp = 0
+        for element in value.split():
+            if exact == 'refcode':
+                if queryset_temp:
+                    queryset_temp = queryset_temp | queryset.filter(refcode__iexact=element)
+                else:
+                    queryset_temp = queryset.filter(refcode__iexact=element)
+            else:
+                if queryset_temp:
+                    queryset_temp = queryset_temp | queryset.filter(refcode__istartswith=element)
+                else:
+                    queryset_temp = queryset.filter(refcode__istartswith=element)
+        return queryset_temp
+    return queryset
+
+
 class StructureFilter(FilterSet):
     # refcode search
     refcode = filters.CharFilter(method='filter_refcode')
@@ -101,22 +122,7 @@ class StructureFilter(FilterSet):
         fields = []
 
     def filter_refcode(self, queryset, name, value):
-        exact = self.request.GET.get('exact', False)
-        if value:
-            queryset_temp = 0
-            for element in value.split():
-                if exact == 'refcode':
-                    if queryset_temp:
-                        queryset_temp = queryset_temp | queryset.filter(refcode__iexact=element)
-                    else:
-                        queryset_temp = queryset.filter(refcode__iexact=element)
-                else:
-                    if queryset_temp:
-                        queryset_temp = queryset_temp | queryset.filter(refcode__istartswith=element)
-                    else:
-                        queryset_temp = queryset.filter(refcode__istartswith=element)
-            return queryset_temp
-        return queryset
+        return general_refcode_filter(self.request, queryset, value)
 
     def filter_CCDC_number(self, queryset, name, value):
         if value:
@@ -279,22 +285,7 @@ class QCStructureFilter(FilterSet):
         fields = []
 
     def filter_refcode(self, queryset, name, value):
-        exact = self.request.GET.get('exact', False)
-        if value:
-            queryset_temp = 0
-            for element in value.split():
-                if exact == 'refcode':
-                    if queryset_temp:
-                        queryset_temp = queryset_temp | queryset.filter(refcode__iexact=element)
-                    else:
-                        queryset_temp = queryset.filter(refcode__iexact=element)
-                else:
-                    if queryset_temp:
-                        queryset_temp = queryset_temp | queryset.filter(refcode__istartswith=element)
-                    else:
-                        queryset_temp = queryset.filter(refcode__istartswith=element)
-            return queryset_temp
-        return queryset
+        return general_refcode_filter(self.request, queryset, value)
 
     def filter_user_db(self, queryset, name, value):
         if value:

--- a/api_database/django_project/modules/gen2d/gen2d.py
+++ b/api_database/django_project/modules/gen2d/gen2d.py
@@ -175,7 +175,12 @@ def draw_and_save_molecule(mol: Chem.Mol, structure_name: str = 'noname'):
     img.save(f'{structure_name}_2d.png')
 
 
-def gen2d(smiles: str = '', inchis: list = [], sanitize: bool = True, size: Tuple[int, int] = (800, 800)):
+def gen2d(smiles: str = '', inchis: list = [], sanitize: bool = True, size: Tuple[int, int] = (800, 800), format: str = 'img'):
+    '''
+    Supported formats:
+        img - 2d image
+        cml - ChemDraw format
+    '''
     mol = None
     # first check smiles
     if smiles:
@@ -190,8 +195,11 @@ def gen2d(smiles: str = '', inchis: list = [], sanitize: bool = True, size: Tupl
                 mol = Chem.CombineMols(mol, temp_mol)
     if mol is None:
         return 0
-    img = Draw.MolToImage(mol, size=size)
-    return img
+    # return formats
+    if format == 'cml':
+        return Chem.MolToCMLBlock(mol)
+    else:
+        return Draw.MolToImage(mol, size=size)
 
 
 def get_symbol_from_element_number(el_number: int, element_numbers: Dict[str, int]) -> str:

--- a/api_database/django_project/structure/models.py
+++ b/api_database/django_project/structure/models.py
@@ -84,7 +84,7 @@ class AbstractStructureCode(models.Model):
     class Meta:
         abstract = True
 
-    def gen_2d_img(self, size=(250, 250), format='gif'):
+    def gen_2d_img(self, size=(250, 250), format='gif', f='img'):
         # TODO: delete this temp function! (keep pregenerated figures in database in base64 format)
         smiles = ''
         if hasattr(self, 'coordinates'):
@@ -94,12 +94,15 @@ class AbstractStructureCode(models.Model):
             inchis = self.inchi.all()
             for inchi in inchis:
                 inchis_list.append(inchi.get_inchi_string())
-        img = gen2d(smiles=smiles, inchis=inchis_list, sanitize=False, size=size)
+        img = gen2d(smiles=smiles, inchis=inchis_list, sanitize=False, size=size, format=f)
         if img:
-            buffer = BytesIO()
-            img.save(buffer, format)
-            img_base64 = f'data:image/{format};base64,' + base64.b64encode(buffer.getvalue()).decode()
-            return img_base64
+            if f == 'img':
+                buffer = BytesIO()
+                img.save(buffer, format)
+                img_base64 = f'data:image/{format};base64,' + base64.b64encode(buffer.getvalue()).decode()
+                return img_base64
+            elif f == 'cml':
+                return img
         return 0
 
 


### PR DESCRIPTION
1. Added new file format for export 2d molecule representation (ChemDraw *.cml file).
2. Modified url for 2d image:  http://127.0.0.1:8000/api/v1/structures/<int>/export/2d/?h=100&w=100&file=1&f=img

- h - height (px), default h=250
- w - weight (px), default w=250
- f - format (f=img - gif image and f=cml - ChemDraw *.cml file format), default i=img
- file - return file or string (file=1 - return file and file=0 - return string), default file=0

3. Fixed bugs.
